### PR TITLE
feat: add support for webhook event secret token & token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ const bot = new TeleBot({
         url: 'https://....', // HTTPS url to send updates to.
         host: '0.0.0.0', // Webhook server host.
         port: 443, // Server port.
-        maxConnections: 40 // Optional. Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery
+        maxConnections: 40, // Optional. Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery
+        secretToken: process.env.SECRET_TOKEN // Optional. A secret token to be sent in a header “X-Telegram-Bot-Api-Secret-Token” in every webhook request, 1-256 characters. Only characters A-Z, a-z, 0-9, _ and - are allowed. The header is useful to ensure that the request comes from a webhook set by you.
     },
     allowedUpdates: [], // Optional. List the types of updates you want your bot to receive. Specify an empty list to receive all updates.
     usePlugins: ['askUser'], // Optional. Use user plugins from pluginFolder.

--- a/examples/webhook.js
+++ b/examples/webhook.js
@@ -8,7 +8,8 @@ const bot = new TeleBot({
         // cert: './cert.pem',
         url: 'https://....',
         host: '0.0.0.0',
-        port: 443
+        port: 443,
+        secretToken: process.env.SECRET_TOKEN
     }
 });
 

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -485,8 +485,12 @@ const methods = {
         arguments: (obj, reply_markup) => editObject(obj, {reply_markup})
     },
 
-    setWebhook(url, certificate, allowedUpdates, maxConnections) {
+    setWebhook(url, certificate, allowedUpdates, maxConnections, secretToken) {
         const form = {url};
+
+        if (secretToken) {
+            form.secret_token = secretToken;
+        }
 
         if (Array.isArray(allowedUpdates)) {
             form.allowed_updates = allowedUpdates;

--- a/lib/telebot.js
+++ b/lib/telebot.js
@@ -160,10 +160,10 @@ class TeleBot {
         // Set webhook
         if (this.webhook) {
 
-            let {url, cert} = this.webhook;
+            let {url, cert, secretToken} = this.webhook;
             if (url) url = `${url}/${this.token}`;
 
-            return this.setWebhook(url, cert, this.allowedUpdates, this.maxConnections).then(() => {
+            return this.setWebhook(url, cert, this.allowedUpdates, this.maxConnections, secretToken).then(() => {
 
                 console.log(`[bot.webhook] set to "${url}"`);
                 return webhook.call(this, this, this.webhook);

--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -12,6 +12,7 @@ module.exports = (bot, opt) => {
     const path = url.parse(opt.url).pathname;
     const key = opt.key && fs.readFileSync(opt.key);
     const cert = opt.cert && fs.readFileSync(opt.cert);
+    const secret_token = opt.secretToken;
 
     // Create server
     const server = key && cert ?
@@ -30,6 +31,12 @@ module.exports = (bot, opt) => {
 
         const botUrl = path && path !== '/' ? path : '';
         const fullPath = botUrl + token;
+        const apiSecretToken = req.headers['x-telegram-bot-api-secret-token'];
+
+        if (secret_token !== apiSecretToken) {
+            console.log('[bot.error.webhook] unrecognized webhook event: secret token does not match')
+            return;
+        }
 
         if (req.url === fullPath && req.method === 'POST') {
 


### PR DESCRIPTION
- additional `secretToken` field for webhook configs
- validate the `x-telegram-bot-api-secret-token` header content from each webhook event